### PR TITLE
Improve RichPath error message.

### DIFF
--- a/dpu_utils/utils/richpath.py
+++ b/dpu_utils/utils/richpath.py
@@ -39,6 +39,7 @@ class RichPath(ABC):
     @staticmethod
     def create(path: str, azure_info_path: Optional[str]=None):
         if path.startswith(AZURE_PATH_PREFIX):
+            assert azure_info_path is not None, "An AzurePath cannot be created when azure_info_path is None."
             # Strip off the AZURE_PATH_PREFIX:
             path = path[len(AZURE_PATH_PREFIX):]
             account_name, container_name, path = path.split('/', 2)


### PR DESCRIPTION
In the case that `azure_info_path` is `None`, reading in L47 fails. This improves the error message.