### PR TITLE
BPE vocabulary based on sentencepiece

### DIFF
--- a/python/dpu_utils/mlutils/__init__.py
+++ b/python/dpu_utils/mlutils/__init__.py
@@ -1,4 +1,5 @@
 from .chartensorizer import CharTensorizer
 from .vocabulary import Vocabulary
+from .bpevocabulary import BpeVocabulary
 
-__all__ = ['CharTensorizer', 'Vocabulary']
+__all__ = ['CharTensorizer', 'Vocabulary', 'BpeVocabulary']

--- a/python/dpu_utils/mlutils/bpevocabulary.py
+++ b/python/dpu_utils/mlutils/bpevocabulary.py
@@ -1,0 +1,141 @@
+import logging
+import os
+from typing import List, Optional
+import sentencepiece as spm
+
+logger = logging.getLogger(__name__)
+
+SPIECE_UNDERLINE = u'▁'
+
+class BpeVocabulary:
+
+    """
+    A vocabulary that maps strings to unique ids (and back), and a tokenizer based on
+    Byte-Pair encoding.
+
+    To create a vocabulary use `BpeVocabulary.create_vocabulary()` and pass
+    a path to plain text file containing input data. The control flow symbols have to be introduced
+    manually, during preprocessing step.
+
+    Vocabulary object usage: Assuming an initialized vocabulary `v`:
+
+       * To get the id of an element use `v.get_id_or_unk("element")`.
+       * To get the ids of a sequence, use `v.get_id_or_unk_multiple(..)`.
+       * To get the size of the vocabulary use `len(v)`
+    """
+
+    def __init__(self, max_size: int, vocab_file: str=None,
+                 bos_token: str="<s>", eos_token: str="</s>", unk_token: str="<unk>", pad_token: str="<pad>", 
+                 user_defined_symbols: List[str]=["<DEDENT>", "<INDENT>", "<NUM_LIT>", "<STR_LIT>"],
+                 control_symbols: List[str]=["<endofline>", "<endoftext>"]) -> None:
+
+        self.max_size=max_size
+        self.bos_token=bos_token
+        self.eos_token=eos_token
+        self.unk_token=unk_token
+        self.pad_token=pad_token
+        self.vocab_file = vocab_file
+        self.user_defined_symbols=",".join(user_defined_symbols)
+        self.control_symbols=",".join(control_symbols)
+
+        self.__sp_model = spm.SentencePieceProcessor()
+        if vocab_file is not None:
+            self.__sp_model.Load(vocab_file)
+
+    def pad_token(self):
+        """ Get padding token (string)"""
+        if self.pad_token is None:
+            logger.error("Using pad_token, but it is not set yet.")
+        return self.pad_token
+
+    def unk_token(self):
+        """ Get unknown token (string) """
+        if self.unk_token is None:
+            logger.error("Using unk_token, but it is not set yet.")
+        return self.unk_token
+
+    def vocab_size(self):
+        return len(self.__sp_model)
+
+    def tokenize(self, text: str) -> List[str]:
+        """ Tokenize a string. """
+        pieces = self.__sp_model.EncodeAsPieces(text)
+
+        new_pieces = []
+        for piece in pieces:
+            if len(piece) > 1 and piece[-1] == ',' and piece[-2].isdigit():
+                cur_pieces = self.__sp_model.EncodeAsPieces(
+                    piece[:-1].replace(SPIECE_UNDERLINE, ''))
+                if piece[0] != SPIECE_UNDERLINE and cur_pieces[0][0] == SPIECE_UNDERLINE:
+                    if len(cur_pieces[0]) == 1:
+                        cur_pieces = cur_pieces[1:]
+                    else:
+                        cur_pieces[0] = cur_pieces[0][1:]
+                cur_pieces.append(piece[-1])
+                new_pieces.extend(cur_pieces)
+            else:
+                new_pieces.append(piece)
+
+        return new_pieces
+
+
+    def get_id_or_unk(self, token: str) -> int:
+        return self._convert_token_to_id(token)
+
+    def get_id_or_unk_multiple(self, tokens: List[str], pad_to_size: Optional[int] = None,
+                               padding_element: int = 0) -> List[int]:
+        if pad_to_size is not None:
+            tokens = tokens[:pad_to_size]
+
+        ids = [self.get_id_or_unk(t) for t in tokens]
+
+        if pad_to_size is not None and len(ids) != pad_to_size:
+            ids += [padding_element] * (pad_to_size - len(ids))
+
+        return ids
+
+    def get_name_for_id(self, token_id: int) -> str:
+        return self._convert_id_to_token(token_id)
+
+    def _convert_token_to_id(self, token: str) -> int:
+        """ Converts a token (str/unicode) in an id using the vocab. """
+        return self.__sp_model.PieceToId(token)
+
+    def _convert_id_to_token(self, index: int) -> str:
+        """Converts an index (integer) in a token (string/unicode) using the vocab."""
+        token = self.__sp_model.IdToPiece(index)
+        return token
+
+    def convert_tokens_to_string(self, tokens: List[str]) -> str:
+        """Converts a sequence of tokens (strings for sub-words) in a single string."""
+        out_string = ''.join(tokens).replace(SPIECE_UNDERLINE, ' ').strip()
+        return out_string
+
+    def create_vocabulary(self, sp_text_file: str, num_threads: int=40, max_sentence_length: int=16384, character_coverage: float=0.99995) -> None:
+        """
+        Train sentencepiece tokenizer using BPE model and build a vocabulary.
+
+        sp_text_file: path to a plain text file containing the training dataset 
+        """
+
+        command = [
+                    f"--input={sp_text_file}",
+                    f"--num_threads={num_threads}",
+                    f"--model_prefix=bpe_{self.max_size}",
+                    f"--vocab_size={self.max_size}",
+                    f"--model_type=bpe",
+                    f"--max_sentence_length={max_sentence_length}",
+                    f"--bos_id={self.bos_token}",
+                    f"--eos_id={self.eos_token}",
+                    f"--pad_id={self.eos_token}",                    
+                    f"--unk_piece={self.unk_token}",
+                    f"--user_defined_symbols={self.user_defined_symbols}",
+                    f"--control_symbols={self.control_symbols}",
+                    f"--character_coverage={character_coverage}",
+                ]
+
+        spm.SentencePieceTrainer.train(
+            " ".join(command)
+        )
+
+        assert self.__sp_model.Load(f"bpe_{self.max_size}.model")

--- a/python/dpu_utils/mlutils/bpevocabulary.py
+++ b/python/dpu_utils/mlutils/bpevocabulary.py
@@ -104,7 +104,14 @@ class BpeVocabulary(Sized):
 
         new_pieces = []   # type: List[str]
         for piece in pieces:
-            # TODO(Alexey): Can you add a comment about what this is doing? I don't understand.
+            # Split subtokens composed of a digit and comma
+            #
+            # E.g. given in an input sentence: 
+            #      text = 'for i in range(100, 2):'
+            # Default output of tokenizer may be: 
+            #      ['▁for', '▁i', '▁in', '▁range', '(1', '00,', '▁2', '):']
+            # Following will change this to: 
+            #      ['▁for', '▁i', '▁in', '▁range', '(1', '0', '0', ',', '▁2', '):']            
             if len(piece) > 1 and piece[-1] == ',' and piece[-2].isdigit():
                 cur_pieces = self.__sp_model.EncodeAsPieces(
                     piece[:-1].replace(SPIECE_UNDERLINE, ''))
@@ -189,4 +196,4 @@ class BpeVocabulary(Sized):
                         else:
                             f.write(' '.join(element))
                             f.write('\n')
-            return self.create_vocabulary_from_file(data_path)
+            return self.create_vocabulary_from_file(data_path)   

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,3 +3,4 @@ tqdm
 docopt
 azure-storage
 numpy
+sentencepiece

--- a/python/tests/mlutils/test_bpevocabulary.py
+++ b/python/tests/mlutils/test_bpevocabulary.py
@@ -1,0 +1,40 @@
+import unittest
+import pickle
+
+from glob import iglob
+import os
+from tempfile import TemporaryDirectory
+
+from dpu_utils.mlutils import BpeVocabulary
+
+
+class TestBpeVocab(unittest.TestCase):
+    def test(self):
+        def pseudotoken_iter():
+            """Create a dummy corpus by using this project."""
+            for filename in iglob(os.path.join(os.path.dirname(__file__), '..', '..', "**/*.py"), recursive=True):
+                with open(filename) as f:
+                    yield from f.read().split('\n')
+
+        v = BpeVocabulary(5000)
+        v.create_vocabulary(pseudotoken_iter())
+        text = 'for i in range(100, 2):'
+        idxs = v.get_id_or_unk_for_text(text)
+
+        self.assertEqual(v.convert_ids_to_string(idxs), text)
+
+        with TemporaryDirectory() as tmp:
+            # Test serialization
+            tmp_filename = os.path.join(tmp, 'tmp.pkl')
+            with open(tmp_filename, 'wb') as f:
+                pickle.dump(v, f)
+
+            with open(tmp_filename, 'rb') as f:
+                v2 = pickle.load(f)
+
+        self.assertEqual(v2.get_id_or_unk_for_text(text), idxs)
+        self.assertEqual(v2.convert_ids_to_string(idxs), text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR proposes a vocabulary class that maps strings to unique ids (and back), and a tokenizer based on Byte-Pair encoding, using sentencepiece implementation (https://github.com/google/sentencepiece).

To create a vocabulary use `BpeVocabulary.create_vocabulary()` and pass a path to plain text file containing input data. The control flow symbols have to be introduced manually, during preprocessing step. Vocabulary object usage: Assuming an initialized vocabulary `v`:
1. To get the id of an element use `v.get_id_or_unk("element")`.
1. To get the ids of a sequence, use `v.get_id_or_unk_multiple(..)`.
1. To get the size of the vocabulary use `len(v)`