### PR TITLE
Bug fix: ChunkWriter with parallel_writers incorrectly writes output.

### DIFF
--- a/python/dpu_utils/utils/chunkwriter.py
+++ b/python/dpu_utils/utils/chunkwriter.py
@@ -73,7 +73,8 @@ class ChunkWriter(Generic[T]):
             '%s%03d%s' % (self.__file_prefix, self.__num_files_written, self.__file_suffix)
         )
         if self.__parallel_writers > 0:
-            self.__writer_executors.submit(lambda: outfile.save_as_compressed_file(self.__current_chunk))
+            to_write = self.__current_chunk
+            self.__writer_executors.submit(lambda: outfile.save_as_compressed_file(to_write))
         else:
             outfile.save_as_compressed_file(self.__current_chunk)
         self.__current_chunk = []

--- a/python/tests/utils/test_chunkwriter.py
+++ b/python/tests/utils/test_chunkwriter.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+from itertools import permutations
+from typing import Set, Callable
+
+from dpu_utils.utils import ChunkWriter, RichPath
+
+
+class TestChunkWriter(unittest.TestCase):
+
+    def test_write_read_standard(self):
+        self.__test_write_read(lambda p: ChunkWriter(p, file_prefix='test', max_chunk_size=123, file_suffix='-test.jsonl.gz'))
+
+    def test_write_read_parallel(self):
+        self.__test_write_read(lambda p: ChunkWriter(p, file_prefix='test', max_chunk_size=123, file_suffix='-test.jsonl.gz', parallel_writers=5))
+
+    def __test_write_read(self, chunk_writer_creator: Callable[[RichPath], ChunkWriter]):
+        all_chars = [chr(65+i) for i in range(26)]
+        ground_elements = set(''.join(t) for t in permutations(all_chars, 3))  # 26^3 elements
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = RichPath.create(tmp)
+            with chunk_writer_creator(tmp_path) as w:
+                w.add_many(ground_elements)
+
+            # Assert that all have been seen
+            stored_elements = set()  # type: Set[str]
+            for file in tmp_path.get_filtered_files_in_dir('test*.jsonl.gz'):
+                stored_elements.update(file.read_as_jsonl())
+
+            assert stored_elements == ground_elements, f'Stored elements differ len(stored)={len(stored_elements)},' \
+                                                       f' len(ground)={len(ground_elements)}.' \
+                                                       f' Diff {ground_elements-stored_elements}.'

--- a/python/tests/utils/test_iterators.py
+++ b/python/tests/utils/test_iterators.py
@@ -1,6 +1,6 @@
 import unittest
 
-from dpu_utils.utils.iterators import shuffled_iterator
+from dpu_utils.utils import shuffled_iterator
 
 
 class TestShuffleIterator(unittest.TestCase):


### PR DESCRIPTION
Previously, the lambdas passed to the ThreadPoolExecutor would capture the field property rather than the actual list to-be copied. By introducing a temporary variable, the correct closure/scope is captured.