### PR TITLE
fix(MLP): add tf name scope to dense layer construction.

### DIFF
--- a/python/dpu_utils/tf2utils/mlp.py
+++ b/python/dpu_utils/tf2utils/mlp.py
@@ -49,26 +49,28 @@ class MLP(tf.keras.layers.Layer):
     def build(self, input_shape):
         last_shape_dim = input_shape[-1]
         for hidden_layer_idx, hidden_layer_size in enumerate(self._hidden_layer_sizes):
+            with tf.name_scope(f"{self._name}_dense_layer_{hidden_layer_idx}"):
+                self._layers.append(
+                    tf.keras.layers.Dense(
+                        units=hidden_layer_size,
+                        use_bias=self._use_biases,
+                        activation=self._activation_fun,
+                        name=f"{self._name}_dense_layer_{hidden_layer_idx}",
+                    )
+                )
+                self._layers[-1].build(tf.TensorShape(input_shape[:-1] + [last_shape_dim]))
+                last_shape_dim = hidden_layer_size
+
+        # Output layer:
+        with tf.name_scope(f"{self._name}_final_layer"):
             self._layers.append(
                 tf.keras.layers.Dense(
-                    units=hidden_layer_size,
+                    units=self._out_size,
                     use_bias=self._use_biases,
-                    activation=self._activation_fun,
-                    name=f"{self._name}_dense_layer_{hidden_layer_idx}",
+                    name=f"{self._name}_final_layer",
                 )
             )
             self._layers[-1].build(tf.TensorShape(input_shape[:-1] + [last_shape_dim]))
-            last_shape_dim = hidden_layer_size
-
-        # Output layer:
-        self._layers.append(
-            tf.keras.layers.Dense(
-                units=self._out_size,
-                use_bias=self._use_biases,
-                name=f"{self._name}_final_layer",
-            )
-        )
-        self._layers[-1].build(tf.TensorShape(input_shape[:-1] + [last_shape_dim]))
 
         super().build(input_shape)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ with open('../README.md') as f:
 
 setuptools.setup(
       name='dpu_utils',
-      version='0.2.5',
+      version='0.2.6',
       license='MIT',
       description='Python utilities used by Deep Procedural Intelligence',
       long_description=long_description,


### PR DESCRIPTION
Setting the `name` variable in the Dense layer constructor does not put the layer weights in that name scope. Having the layer weights in a specified name scope is desirable because saving & loading weights by name works only when all of the weights in the constructed model have unique names.

Note: a change to indentation level has made the diff for this PR more confusing than necessary. There are only 2 line additions (`with tf.name_scope...`). All other changes are indentation.