### PR TITLE
Make thread in ThreadedIterator a daemon.

### DIFF
--- a/python/dpu_utils/utils/iterators.py
+++ b/python/dpu_utils/utils/iterators.py
@@ -19,7 +19,7 @@ class ThreadedIterator(Iterator[T]):
         self.__is_enabled = enabled
         if enabled:
             self.__queue = queue.Queue(maxsize=max_queue_size)  # type: queue.Queue[Optional[T]]
-            self.__thread = threading.Thread(target=lambda: self.__worker(self.__queue, original_iterator))
+            self.__thread = threading.Thread(target=lambda: self.__worker(self.__queue, original_iterator), daemon=True)
             self.__thread.start()
         else:
             self.__original_iterator = original_iterator

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,4 +4,4 @@ docopt
 azure-storage==0.36.0
 numpy
 typing_extensions
-sentencepiece
+sentencepiece==0.1.92


### PR DESCRIPTION
This makes the thread of the `ThreadedIterator` a daemon (see [here](https://docs.python.org/3.8/library/threading.html#threading.Thread.daemon)).

This resolves the case, when the main thread finishes (_e.g._ an exception is thrown) but a `ThreadedIterator` blocks the program from exiting.