### PR TITLE
Get most of previous behavior for identifier splitting

### DIFF
--- a/python/dpu_utils/codeutils/identifiersplitting.py
+++ b/python/dpu_utils/codeutils/identifiersplitting.py
@@ -6,9 +6,9 @@ REGEX_TEXT = ("(?<=[a-z0-9])(?=[A-Z])|"
               "(?<=[A-Z0-9])(?=[A-Z][a-z])|"
               "(?<=[0-9])(?=[a-zA-Z])|"
               "(?<=[A-Za-z])(?=[0-9])|"
-              "(?<=[@$])(?=[a-zA-Z0-9])|"
-              "(?<=[a-zA-Z0-9])(?=[@$])|"
-              "_")
+              "(?<=[@$.'\"])(?=[a-zA-Z0-9])|"
+              "(?<=[a-zA-Z0-9])(?=[@$.'\"])|"
+              "_|\\s+")
 
 if sys.version_info >= (3, 7):
     import re
@@ -23,7 +23,7 @@ def split_identifier_into_parts(identifier: str) -> List[str]:
     """
     Split a single identifier into parts on snake_case and camelCase
     """
-    identifier_parts = list(s for s in SPLIT_REGEX.split(identifier) if len(s)>0)
+    identifier_parts = list(s.lower() for s in SPLIT_REGEX.split(identifier) if len(s)>0)
 
     if len(identifier_parts) == 0:
         return [identifier]


### PR DESCRIPTION
The updated identifier splitting was quite different. The following behaviors are changed back to make it as backwards-compatible as possible:
* lowercase subtokens
* Split on spaces, dots, quotes