### PR TITLE
files from repo should not be required for build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,10 @@
-import setuptools
+import setuptools, os
 
-with open('../README.md') as f:
-    long_description = f.read()
+if os.file.exists('../README.md'):
+    with open('../README.md') as f:
+        long_description = f.read()
+else:
+    long_description = ""
 
 setuptools.setup(
       name='dpu_utils',

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,7 +8,7 @@ else:
 
 setuptools.setup(
       name='dpu_utils',
-      version='0.4.1',
+      version='0.4.2',
       license='MIT',
       description='Python utilities used by Deep Procedural Intelligence',
       long_description=long_description,


### PR DESCRIPTION
Hello Maintainer(s),

The file `README.md` should be optional when creating a package OR it should be included in the [PyPi tar file](https://files.pythonhosted.org/packages/1d/d7/8fe2f11290f87982e14eb7b5498d3984ab02407da6896b07de1ccbe458e7/dpu_utils-0.4.1.tar.gz). Otherwise, it is creating a build failure during [conda package creation](https://github.com/conda-forge/staged-recipes/pull/15363).

Would greatly appreciate it if you could merge this and push a new build to pip. I can pick the new one for [the conda recipe](https://github.com/microsoft/dpu-utils/issues/69). 

Cheers,
Sarthak 