### PR TITLE
Resolve hanging-processes issue with parallel iterators

### DIFF
--- a/python/dpu_utils/utils/iterators.py
+++ b/python/dpu_utils/utils/iterators.py
@@ -67,9 +67,9 @@ class MultiWorkerCallableIterator(Iterable):
             maxsize=max_queue_size
         )  # type: Union[queue.Queue, multiprocessing.Queue]
         self.__threads = [
-            threading.Thread(target=lambda: MultiWorkerCallableIterator._worker(self.__in_queue, self.__out_queue, worker_callable)) if use_threads
+            threading.Thread(target=lambda: MultiWorkerCallableIterator._worker(self.__in_queue, self.__out_queue, worker_callable), daemon=True) if use_threads
             else multiprocessing.Process(
-                target=partial(MultiWorkerCallableIterator._worker, self.__in_queue, self.__out_queue, worker_callable)
+                target=partial(MultiWorkerCallableIterator._worker, self.__in_queue, self.__out_queue, worker_callable), daemon=True
             ) for _ in range(num_workers)
         ]  # type: List[Union[threading.Thread, multiprocessing.Process]]
         for worker in self.__threads:
@@ -109,7 +109,7 @@ class BufferedIterator(Iterable[T]):
 
         if enabled:
             self.__buffer = multiprocessing.Queue(maxsize=max_queue_size)  # type: multiprocessing.Queue[Union[None, T, Tuple[Exception, Any]]]
-            self.__worker_process = multiprocessing.Process(target=partial(BufferedIterator._worker, self.__buffer, original_iterator))
+            self.__worker_process = multiprocessing.Process(target=partial(BufferedIterator._worker, self.__buffer, original_iterator), daemon=True)
             self.__worker_process.start()
 
     @staticmethod
@@ -152,8 +152,8 @@ class DoubleBufferedIterator(Iterator[T]):
         if enabled:
             self.__buffer_inner = multiprocessing.Queue(maxsize=max_queue_size_inner)  # type: multiprocessing.Queue[Union[None, T, Tuple[Exception, Any]]]
             self.__buffer_outer = multiprocessing.Queue(maxsize=max_queue_size_outer)  # type: multiprocessing.Queue[Union[None, T, Tuple[Exception, Any]]]
-            self.__worker_process_inner = multiprocessing.Process(target=partial(DoubleBufferedIterator._worker_inner, self.__buffer_inner, original_iterable))
-            self.__worker_process_outer = multiprocessing.Process(target=partial(DoubleBufferedIterator._worker_outer, self.__buffer_inner, self.__buffer_outer))
+            self.__worker_process_inner = multiprocessing.Process(target=partial(DoubleBufferedIterator._worker_inner, self.__buffer_inner, original_iterable), daemon=True)
+            self.__worker_process_outer = multiprocessing.Process(target=partial(DoubleBufferedIterator._worker_outer, self.__buffer_inner, self.__buffer_outer), daemon=True)
             self.__worker_process_inner.start()
             self.__worker_process_outer.start()
             self.__original_iterable = None

--- a/python/tests/utils/test_iterators.py
+++ b/python/tests/utils/test_iterators.py
@@ -1,5 +1,6 @@
 import unittest
 from functools import partial
+from itertools import islice
 
 from dpu_utils.utils import shuffled_iterator, ThreadedIterator, BufferedIterator, DoubleBufferedIterator, MultiWorkerCallableIterator
 
@@ -48,3 +49,12 @@ class TestParellelIterators(unittest.TestCase):
                         with self.subTest("%s-%s-%s-enabled=%s" % (iterator_type, size, iter_kind, enabled)):
                             returned = list(iterator_type(iter_kind, enabled=enabled))
                             self.assertListEqual(returned, list(range(size)), f'Iterator {iterator_type.__name__} did not return all elements.')
+
+
+    def test_finish_on_partial_iteration(self):
+        """Parallel iterators may leave resources (threads, processes) on partial iteration. Ensure that's not the case."""
+        for iterator_type in self.ALL_ITERATOR_TYPES:
+            for iter_kind in (range(100), generator(100), IterWrapper(partial(generator, 100))):
+                with self.subTest("%s=%s" % (iterator_type, iter_kind)):
+                    returned = list(islice(iterator_type(iter_kind), 10))
+        # The test always finishes normally, but the pytest process should _not_ hang due to unfinished threads/processes.


### PR DESCRIPTION
This makes all threads/processes daemonic, which ensures that the program terminates even if an iteration has been interrupted (e.g. due to an OOM). See [here](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.daemon) for a description.

A new limitation is that the process-based iterators should not be creating processes itself.